### PR TITLE
Add PHP Class Signature Source for generating clean class interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 Context Generator is a PHP tool that helps developers build structured context files from various sources:
 
 - code files,
+- PHP class signatures (without implementation details),
 - URLs,
 - and plain text.
 
@@ -139,6 +140,18 @@ return (new DocumentRegistry())
                 selector: '.main-content',
             ),
         ),
+    )
+    ->register(
+        Document::create(
+            description: 'API Class Signatures',
+            outputPath: 'docs/api-interfaces.md',
+        )
+        ->addSource(
+            new PhpClassSource(
+                sourcePaths: __DIR__ . '/src/Api',
+                description: 'API Class Definitions',
+            ),
+        ),
     );
 ```
 
@@ -184,6 +197,19 @@ or
           "selector": ".main-content"
         }
       ]
+    },
+    {
+      "description": "API Class Signatures",
+      "outputPath": "docs/api-interfaces.md",
+      "sources": [
+        {
+          "type": "phpClass",
+          "description": "API Class Definitions",
+          "sourcePaths": [
+            "src/Api"
+          ]
+        }
+      ]
     }
   ]
 }
@@ -199,6 +225,23 @@ Then run the command:
 ```
 
 ## Source Types
+
+### PhpClassSource
+
+The `Butschster\ContextGenerator\Source\PhpClassSource` allows you to extract class signatures from PHP files without implementation details:
+
+```php
+use Butschster\ContextGenerator\Source\PhpClassSource;
+
+new PhpClassSource(
+    sourcePaths: __DIR__ . '/src',        // Path to directory or file with PHP classes
+    description: 'Class Signatures',      // Optional description
+    filePattern: '*.php',                 // File pattern to match (default: *.php)
+    excludePatterns: ['tests', 'vendor'], // Patterns to exclude
+    showTreeView: true,                   // Whether to show tree view (default: true)
+    onlySignatures: true                  // Whether to include only class signatures (default: true)
+);
+```
 
 ### FileSource
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "symfony/finder": "^6.0 | ^7.0 | ^8.0",
-    "symfony/console": "^6.0 | ^7.0 | ^8.0"
+    "symfony/console": "^6.0 | ^7.0 | ^8.0",
+    "nette/php-generator": "^4.1"
   },
   "require-dev": {
     "symfony/http-client": "^7.0 | ^8.0",

--- a/src/Cli/ContextGenerator.php
+++ b/src/Cli/ContextGenerator.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Cli;
 use Butschster\ContextGenerator\DocumentCompiler;
 use Butschster\ContextGenerator\Fetcher\FileSourceFetcher;
 use Butschster\ContextGenerator\Fetcher\HtmlCleaner;
+use Butschster\ContextGenerator\Fetcher\PhpFileSourceFetcher;
 use Butschster\ContextGenerator\Fetcher\SourceFetcherRegistry;
 use Butschster\ContextGenerator\Fetcher\TextSourceFetcher;
 use Butschster\ContextGenerator\Fetcher\UrlSourceFetcher;
@@ -45,6 +46,9 @@ final class ContextGenerator extends Command
         $sourceFetcherRegistry = new SourceFetcherRegistry(
             fetchers: [
                 new TextSourceFetcher(),
+                new PhpFileSourceFetcher(
+                    basePath: $this->rootPath,
+                ),
                 new FileSourceFetcher(
                     basePath: $this->rootPath,
                 ),

--- a/src/DocumentCompiler.php
+++ b/src/DocumentCompiler.php
@@ -37,10 +37,7 @@ final readonly class DocumentCompiler
     private function buildContent(Document $document): string
     {
         // Add document description
-        $content = "DOCUMENT: {$document->description}" . PHP_EOL . PHP_EOL;
-
-        $content .= "SOURCES:" . PHP_EOL;
-        $content .= '==========================================================' . PHP_EOL . PHP_EOL;
+        $content = "## DOCUMENT: {$document->description}" . PHP_EOL . PHP_EOL;
 
         // Process all sources
         foreach ($document->getSources() as $source) {
@@ -50,7 +47,10 @@ final readonly class DocumentCompiler
 
             $content .= $source->parseContent($this->parser);
             $content .= PHP_EOL;
+            $content .= '---' . PHP_EOL;
         }
+
+        $content .= PHP_EOL;
 
         // Remove empty lines at the beginning of each line
         return \preg_replace('/^\s*[\r\n]+/m', '', $content);

--- a/src/Fetcher/PhpClassParser.php
+++ b/src/Fetcher/PhpClassParser.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Fetcher;
+
+use Nette\PhpGenerator\ClassLike;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\EnumType;
+use Nette\PhpGenerator\InterfaceType;
+use Nette\PhpGenerator\PhpFile;
+use Nette\PhpGenerator\TraitType;
+
+/**
+ * Parser for PHP class files to extract signatures without implementation details.
+ * Uses Nette PHP Generator for robust parsing.
+ */
+final class PhpClassParser
+{
+    private const MAGIC_METHODS = [
+        '__construct',
+    ];
+
+    /**
+     * Parse a PHP file and extract class signatures
+     */
+    public function parse(string $content): string
+    {
+        try {
+            $file = PhpFile::fromCode($content);
+
+            $output = '';
+            foreach ($file->getNamespaces() as $namespace) {
+                $output .= "namespace {$namespace->getName()};\n\n";
+
+                foreach ($namespace->getUses() as $use) {
+                    $output .= "use $use;\n";
+                }
+
+                foreach ($namespace->getClasses() as $class) {
+                    $output .= $this->processClass($class);
+                }
+            }
+
+            return $output;
+        } catch (\Throwable $e) {
+            return "// Error parsing file: {$e->getMessage()}\n";
+        }
+    }
+
+    /**
+     * Process a class and generate its signature
+     */
+    private function processClass(ClassLike $class): string
+    {
+        $output = '';
+
+        // Determine class type and generate signature
+        if ($class->isInterface()) {
+            $output .= $this->generateInterfaceSignature($class);
+        } elseif ($class->isTrait()) {
+            $output .= $this->generateTraitSignature($class);
+        } elseif (PHP_VERSION_ID >= 80100 && method_exists($class, 'isEnum') && $class->isEnum()) {
+            $output .= $this->generateEnumSignature($class);
+        } else {
+            $output .= $this->generateClassSignature($class);
+        }
+
+        return $output . "\n";
+    }
+
+    /**
+     * Generate class signature
+     */
+    private function generateClassSignature(ClassType $class): string
+    {
+        // Remove method bodies
+        foreach ($class->getMethods() as $method) {
+            // if is magic method, skip
+            if (\in_array($method->getName(), self::MAGIC_METHODS, true)) {
+                continue;
+            }
+
+            if (!$method->isPublic()) {
+                $class->removeMethod($method->getName());
+            }
+
+            $method->setBody($method->isAbstract() ? '' : '/* ... */');
+        }
+
+        // Generate the class code
+        return (string) $class;
+    }
+
+    /**
+     * Generate interface signature
+     */
+    private function generateInterfaceSignature(InterfaceType $interface): string
+    {
+        // Generate the interface code
+        return (string) $interface;
+    }
+
+    /**
+     * Generate trait signature
+     */
+    private function generateTraitSignature(TraitType $trait): string
+    {
+        foreach ($trait->getMethods() as $method) {
+            if (!$method->isPublic()) {
+                $trait->removeMethod($method->getName());
+            }
+            $method->setBody('/* ... */');
+        }
+
+        // Generate the trait code
+        return (string) $trait;
+    }
+
+    /**
+     * Generate enum signature (PHP 8.1+)
+     */
+    private function generateEnumSignature(EnumType $enum): string
+    {
+        // Remove method bodies
+        foreach ($enum->getMethods() as $method) {
+            if (!$method->isPublic()) {
+                $enum->removeMethod($method->getName());
+            }
+            $method->setBody('/* ... */');
+        }
+
+        // Generate the enum code
+        return (string) $enum;
+    }
+}

--- a/src/Fetcher/PhpFileSourceFetcher.php
+++ b/src/Fetcher/PhpFileSourceFetcher.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Fetcher;
+
+use Butschster\ContextGenerator\Source\PhpClassSource;
+use Butschster\ContextGenerator\SourceInterface;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * @implements SourceFetcherInterface<PhpClassSource>
+ */
+final readonly class PhpFileSourceFetcher extends FileSourceFetcher
+{
+    public function __construct(
+        string $basePath,
+        FileTreeBuilder $treeBuilder = new FileTreeBuilder(),
+        private PhpClassParser $classParser = new PhpClassParser(),
+    ) {
+        parent::__construct($basePath, $treeBuilder);
+    }
+
+    public function supports(SourceInterface $source): bool
+    {
+        return $source instanceof PhpClassSource;
+    }
+
+    protected function getContent(SplFileInfo $file, SourceInterface $source): string
+    {
+        return \str_replace(
+            ['<?php', 'declare(strict_types=1);'],
+            '',
+            $source->onlySignatures ? $this->classParser->parse($file->getContents()) : $file->getContents(),
+        );
+    }
+}

--- a/src/Source/FileSource.php
+++ b/src/Source/FileSource.php
@@ -7,7 +7,7 @@ namespace Butschster\ContextGenerator\Source;
 /**
  * Source for files and directories
  */
-final class FileSource extends BaseSource
+class FileSource extends BaseSource
 {
     /**
      * @param string $description Human-readable description

--- a/src/Source/PhpClassSource.php
+++ b/src/Source/PhpClassSource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Source;
+
+final class PhpClassSource extends FileSource
+{
+    public function __construct(
+        array|string $sourcePaths,
+        string $description = '',
+        string $filePattern = '*.php',
+        array $excludePatterns = [],
+        bool $showTreeView = true,
+        public readonly bool $onlySignatures = true,
+    ) {
+        parent::__construct($sourcePaths, $description, $filePattern, $excludePatterns, $showTreeView);
+    }
+}


### PR DESCRIPTION
This feature allows extraction of PHP class signatures without implementation details, which is useful for creating architecture documentation without implementation noise