### PR TITLE
 Add support for multiple file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ return (new DocumentRegistry())
             new FileSource(
                 sourcePaths: __DIR__ . '/src/Api',
                 description: 'API Source Files',
-                filePattern: '*.php',
+                filePattern: ['*.php', '*.md', '*.json'], // by default *.*
                 excludePatterns: ['tests', 'vendor'],
                 showTreeView: true,
                 modifiers: ['php-signature'],
@@ -182,7 +182,7 @@ or
           "sourcePaths": [
             "src/Api"
           ],
-          "filePattern": "*.php",
+          "filePattern": ["*.php", "*.md", "*.json"],
           "excludePatterns": [
             "tests",
             "vendor"

--- a/json-schema.json
+++ b/json-schema.json
@@ -182,8 +182,19 @@
           ]
         },
         "filePattern": {
-          "type": "string",
-          "description": "Pattern to match files (e.g., *.php)",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Pattern to match files (e.g., *.php)"
+            },
+            {
+              "type": "array",
+              "description": "List of patterns to match files (e.g., ['*.php', '*.md'])",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
           "default": "*.*"
         },
         "excludePatterns": {
@@ -304,8 +315,19 @@
           "default": "main"
         },
         "filePattern": {
-          "type": "string",
-          "description": "Pattern to match files (e.g., *.php)",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Pattern to match files (e.g., *.php)"
+            },
+            {
+              "type": "array",
+              "description": "List of patterns to match files (e.g., ['*.php', '*.md'])",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
           "default": "*.php"
         },
         "excludePatterns": {

--- a/src/Document.php
+++ b/src/Document.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator;
 
-final class Document
+final class Document implements \JsonSerializable
 {
     /** @var array<SourceInterface> */
     private array $sources = [];
@@ -55,5 +55,15 @@ final class Document
     public function getSources(): array
     {
         return $this->sources;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'description' => $this->description,
+            'outputPath' => $this->outputPath,
+            'overwrite' => $this->overwrite,
+            'sources' => $this->sources,
+        ]);
     }
 }

--- a/src/DocumentRegistry.php
+++ b/src/DocumentRegistry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator;
 
-final class DocumentRegistry
+final class DocumentRegistry implements \JsonSerializable
 {
     /**
      * @var array<Document>
@@ -34,5 +34,12 @@ final class DocumentRegistry
     public function getDocuments(): array
     {
         return $this->documents;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'documents' => $this->documents,
+        ];
     }
 }

--- a/src/Loader/JsonConfigDocumentsLoader.php
+++ b/src/Loader/JsonConfigDocumentsLoader.php
@@ -4,25 +4,26 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Loader;
 
-use Butschster\ContextGenerator\Document;
 use Butschster\ContextGenerator\DocumentRegistry;
 use Butschster\ContextGenerator\DocumentsLoaderInterface;
 use Butschster\ContextGenerator\FilesInterface;
-use Butschster\ContextGenerator\Source\FileSource;
-use Butschster\ContextGenerator\Source\GithubSource;
-use Butschster\ContextGenerator\Source\TextSource;
-use Butschster\ContextGenerator\Source\UrlSource;
 
 final readonly class JsonConfigDocumentsLoader implements DocumentsLoaderInterface
 {
+    private JsonConfigParser $parser;
+
     /**
      * @param string $configPath Path to JSON configuration file (relative to root or absolute)
      */
     public function __construct(
         private FilesInterface $files,
         private string $configPath,
-        private string $rootPath,
-    ) {}
+        string $rootPath,
+    ) {
+        $this->parser = new JsonConfigParser(
+            rootPath: $rootPath,
+        );
+    }
 
     public function load(): DocumentRegistry
     {
@@ -45,251 +46,7 @@ final readonly class JsonConfigDocumentsLoader implements DocumentsLoaderInterfa
             );
         }
 
-        return $this->createDocumentRegistry($config);
-    }
-
-    /**
-     * Create a DocumentRegistry from the decoded JSON configuration.
-     */
-    private function createDocumentRegistry(array $config): DocumentRegistry
-    {
-        $registry = new DocumentRegistry();
-
-        foreach ($config['documents'] as $index => $docData) {
-            if (!isset($docData['description'], $docData['outputPath'])) {
-                throw new \RuntimeException(
-                    sprintf('Document at index %d must have "description" and "outputPath"', $index),
-                );
-            }
-
-            $document = Document::create(
-                description: (string) $docData['description'],
-                outputPath: (string) $docData['outputPath'],
-                overwrite: (bool) ($docData['overwrite'] ?? true),
-            );
-
-            if (isset($docData['sources']) && \is_array($docData['sources'])) {
-                foreach ($docData['sources'] as $sourceIndex => $sourceData) {
-                    $source = $this->createSource($sourceData, "$index.$sourceIndex");
-                    if ($source !== null) {
-                        $document->addSource($source);
-                    }
-                }
-            }
-
-            $registry->register($document);
-        }
-
-        return $registry;
-    }
-
-    /**
-     * Create a Source object from its configuration.
-     */
-    private function createSource(array $sourceData, string $path): ?object
-    {
-        if (!isset($sourceData['type'])) {
-            throw new \RuntimeException(
-                \sprintf('Source at path %s must have a "type" property', $path),
-            );
-        }
-
-        $description = $sourceData['description'] ?? '';
-
-        return match ($sourceData['type']) {
-            'file' => $this->createFileSource($sourceData, $path, $description),
-            'url' => $this->createUrlSource($sourceData, $path, $description),
-            'text' => $this->createTextSource($sourceData, $path, $description),
-            'github' => $this->createGithubSource($sourceData, $path, $description),
-            default => throw new \RuntimeException(
-                \sprintf('Unknown source type "%s" at path %s', $sourceData['type'], $path),
-            ),
-        };
-    }
-
-    /**
-     * Parse modifiers configuration
-     *
-     * @param array<mixed> $modifiersConfig
-     * @return array<string|array{name: string, options: array<string, mixed>}>
-     */
-    private function parseModifiers(array $modifiersConfig): array
-    {
-        $result = [];
-
-        foreach ($modifiersConfig as $modifier) {
-            if (\is_string($modifier)) {
-                $result[] = $modifier;
-            } elseif (\is_array($modifier) && isset($modifier['name'])) {
-                $result[] = [
-                    'name' => $modifier['name'],
-                    'options' => $modifier['options'] ?? [],
-                ];
-            } else {
-                throw new \InvalidArgumentException(
-                    sprintf('Invalid modifier format: %s', json_encode($modifier)),
-                );
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * Create a GithubSource from its configuration.
-     */
-    private function createGithubSource(
-        array $data,
-        string $path,
-        string $description,
-    ): GithubSource {
-        if (!isset($data['repository'])) {
-            throw new \RuntimeException(
-                \sprintf('GitHub source at path %s must have a "repository" property', $path),
-            );
-        }
-
-        // Determine source paths (required)
-        if (!isset($data['sourcePaths'])) {
-            throw new \RuntimeException(
-                \sprintf('GitHub source at path %s must have a "sourcePaths" property', $path),
-            );
-        }
-
-        $sourcePaths = $data['sourcePaths'];
-        if (!\is_string($sourcePaths) && !\is_array($sourcePaths)) {
-            throw new \RuntimeException(
-                \sprintf('"sourcePaths" must be a string or array in source at path %s', $path),
-            );
-        }
-
-        // Convert to array if single string
-        $sourcePaths = \is_string($sourcePaths) ? [$sourcePaths] : $sourcePaths;
-
-        return new GithubSource(
-            repository: $data['repository'],
-            sourcePaths: $sourcePaths,
-            branch: $data['branch'] ?? 'main',
-            description: $description,
-            filePattern: $data['filePattern'] ?? '*.php',
-            excludePatterns: $data['excludePatterns'] ?? [],
-            showTreeView: $data['showTreeView'] ?? true,
-            githubToken: $this->parseConfigValue($data['githubToken'] ?? null),
-            modifiers: $this->parseModifiers($data['modifiers'] ?? []),
-        );
-    }
-
-    /**
-     * Parse a configuration value, resolving environment variables if needed.
-     *
-     * @param string|null $value The configuration value to parse
-     * @return string|null The parsed value
-     */
-    private function parseConfigValue(?string $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        // Check if the value is an environment variable reference
-        if (\preg_match('/^\${([A-Za-z0-9_]+)}$/', $value, $matches)) {
-            // Get the environment variable name
-            $envName = $matches[1];
-
-            // Get the value from environment
-            $envValue = getenv($envName);
-
-            // Return the environment variable value or null if not set
-            return $envValue !== false ? $envValue : null;
-        }
-
-        // Check if the value has embedded environment variables
-        if (\preg_match_all('/\${([A-Za-z0-9_]+)}/', $value, $matches)) {
-            // Replace all environment variables in the string
-            foreach ($matches[0] as $index => $placeholder) {
-                $envName = $matches[1][$index];
-                $envValue = \getenv($envName);
-
-                if ($envValue !== false) {
-                    $value = \str_replace($placeholder, $envValue, $value);
-                }
-            }
-        }
-
-        return $value;
-    }
-
-    /**
-     * Create a FileSource from its configuration.
-     */
-    private function createFileSource(
-        array $data,
-        string $path,
-        string $description,
-    ): FileSource {
-        if (!isset($data['sourcePaths'])) {
-            throw new \RuntimeException(
-                \sprintf('File source at path %s must have a "sourcePaths" property', $path),
-            );
-        }
-
-        $sourcePaths = $data['sourcePaths'];
-
-        if (!\is_string($sourcePaths) && !\is_array($sourcePaths)) {
-            throw new \RuntimeException(
-                \sprintf('"sourcePaths" must be a string or array in source at path %s', $path),
-            );
-        }
-
-        $sourcePaths = \is_string($sourcePaths) ? [$sourcePaths] : $sourcePaths;
-        $sourcePaths = \array_map(
-            fn(string $sourcePath): string => $this->rootPath . '/' . \trim($sourcePath, '/'),
-            $sourcePaths,
-        );
-
-        return new FileSource(
-            sourcePaths: $sourcePaths,
-            description: $description,
-            filePattern: $data['filePattern'] ?? '*.*',
-            excludePatterns: $data['excludePatterns'] ?? [],
-            showTreeView: $data['showTreeView'] ?? true,
-            modifiers: $this->parseModifiers($data['modifiers'] ?? []),
-        );
-    }
-
-    /**
-     * Create a UrlSource from its configuration.
-     */
-    private function createUrlSource(array $data, string $path, string $description): UrlSource
-    {
-        if (!isset($data['urls']) || !\is_array($data['urls'])) {
-            throw new \RuntimeException(
-                \sprintf('URL source at path %s must have a "urls" array property', $path),
-            );
-        }
-
-        return new UrlSource(
-            urls: $data['urls'],
-            description: $description,
-            selector: $data['selector'] ?? null,
-        );
-    }
-
-    /**
-     * Create a TextSource from its configuration.
-     */
-    private function createTextSource(array $data, string $path, string $description): TextSource
-    {
-        if (!isset($data['content']) || !\is_string($data['content'])) {
-            throw new \RuntimeException(
-                \sprintf('Text source at path %s must have a "content" string property', $path),
-            );
-        }
-
-        return new TextSource(
-            content: $data['content'],
-            description: $description,
-        );
+        return $this->parser->parse($config);
     }
 
     public function isSupported(): bool

--- a/src/Loader/JsonConfigParser.php
+++ b/src/Loader/JsonConfigParser.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Loader;
+
+use Butschster\ContextGenerator\Document;
+use Butschster\ContextGenerator\DocumentRegistry;
+use Butschster\ContextGenerator\Source\FileSource;
+use Butschster\ContextGenerator\Source\GithubSource;
+use Butschster\ContextGenerator\Source\TextSource;
+use Butschster\ContextGenerator\Source\UrlSource;
+
+final readonly class JsonConfigParser
+{
+    public function __construct(
+        private string $rootPath,
+    ) {}
+
+    /**
+     * Create a DocumentRegistry from the decoded JSON configuration.
+     */
+    public function parse(array $config): DocumentRegistry
+    {
+        $registry = new DocumentRegistry();
+
+        foreach ($config['documents'] as $index => $docData) {
+            if (!isset($docData['description'], $docData['outputPath'])) {
+                throw new \RuntimeException(
+                    sprintf('Document at index %d must have "description" and "outputPath"', $index),
+                );
+            }
+
+            $document = Document::create(
+                description: (string) $docData['description'],
+                outputPath: (string) $docData['outputPath'],
+                overwrite: (bool) ($docData['overwrite'] ?? true),
+            );
+
+            if (isset($docData['sources']) && \is_array($docData['sources'])) {
+                foreach ($docData['sources'] as $sourceIndex => $sourceData) {
+                    $source = $this->createSource($sourceData, "$index.$sourceIndex");
+                    if ($source !== null) {
+                        $document->addSource($source);
+                    }
+                }
+            }
+
+            $registry->register($document);
+        }
+
+        return $registry;
+    }
+
+    /**
+     * Create a Source object from its configuration.
+     */
+    private function createSource(array $sourceData, string $path): ?object
+    {
+        if (!isset($sourceData['type'])) {
+            throw new \RuntimeException(
+                \sprintf('Source at path %s must have a "type" property', $path),
+            );
+        }
+
+        return match ($sourceData['type']) {
+            'file' => $this->createFileSource($sourceData, $path),
+            'url' => $this->createUrlSource($sourceData, $path),
+            'text' => $this->createTextSource($sourceData, $path),
+            'github' => $this->createGithubSource($sourceData, $path),
+            default => throw new \RuntimeException(
+                \sprintf('Unknown source type "%s" at path %s', $sourceData['type'], $path),
+            ),
+        };
+    }
+
+    /**
+     * Parse modifiers configuration
+     *
+     * @param array<mixed> $modifiersConfig
+     * @return array<string|array{name: string, options: array<string, mixed>}>
+     */
+    private function parseModifiers(array $modifiersConfig): array
+    {
+        $result = [];
+
+        foreach ($modifiersConfig as $modifier) {
+            if (\is_string($modifier)) {
+                $result[] = $modifier;
+            } elseif (\is_array($modifier) && isset($modifier['name'])) {
+                $result[] = [
+                    'name' => $modifier['name'],
+                    'options' => $modifier['options'] ?? [],
+                ];
+            } else {
+                throw new \InvalidArgumentException(
+                    sprintf('Invalid modifier format: %s', json_encode($modifier)),
+                );
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Create a GithubSource from its configuration.
+     */
+    private function createGithubSource(
+        array $data,
+        string $path,
+    ): GithubSource {
+        if (isset($data['githubToken'])) {
+            $data['githubToken'] = $this->parseConfigValue($data['githubToken']);
+        }
+
+        return GithubSource::fromArray($data);
+    }
+
+    /**
+     * Parse a configuration value, resolving environment variables if needed.
+     *
+     * @param string|null $value The configuration value to parse
+     * @return string|null The parsed value
+     */
+    private function parseConfigValue(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        // Check if the value is an environment variable reference
+        if (\preg_match('/^\${([A-Za-z0-9_]+)}$/', $value, $matches)) {
+            // Get the environment variable name
+            $envName = $matches[1];
+
+            // Get the value from environment
+            $envValue = getenv($envName);
+
+            // Return the environment variable value or null if not set
+            return $envValue !== false ? $envValue : null;
+        }
+
+        // Check if the value has embedded environment variables
+        if (\preg_match_all('/\${([A-Za-z0-9_]+)}/', $value, $matches)) {
+            // Replace all environment variables in the string
+            foreach ($matches[0] as $index => $placeholder) {
+                $envName = $matches[1][$index];
+                $envValue = \getenv($envName);
+
+                if ($envValue !== false) {
+                    $value = \str_replace($placeholder, $envValue, $value);
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Create a FileSource from its configuration.
+     */
+    private function createFileSource(array $data, string $path): FileSource
+    {
+        if (isset($data['modifiers'])) {
+            $data['modifiers'] = $this->parseModifiers($data['modifiers']);
+        }
+
+        return FileSource::fromArray($data, $this->rootPath);
+    }
+
+    /**
+     * Create a UrlSource from its configuration.
+     */
+    private function createUrlSource(array $data, string $path): UrlSource
+    {
+        return UrlSource::fromArray($data);
+    }
+
+    /**
+     * Create a TextSource from its configuration.
+     */
+    private function createTextSource(array $data, string $path): TextSource
+    {
+        return TextSource::fromArray($data);
+    }
+}
+
+

--- a/src/Source/FileSource.php
+++ b/src/Source/FileSource.php
@@ -27,10 +27,29 @@ class FileSource extends BaseSource
             $sourcePaths,
         );
 
+        // Validate filePattern if present
+        if (isset($data['filePattern'])) {
+            if (!\is_string($data['filePattern']) && !is_array($data['filePattern'])) {
+                throw new \RuntimeException('filePattern must be a string or an array of strings');
+            }
+
+            // If it's an array, make sure all elements are strings
+            if (\is_array($data['filePattern'])) {
+                foreach ($data['filePattern'] as $pattern) {
+                    if (!\is_string($pattern)) {
+                        throw new \RuntimeException('All elements in filePattern must be strings');
+                    }
+                }
+            }
+        }
+
+        // Handle filePattern parameter, allowing both string and array formats
+        $filePattern = $data['filePattern'] ?? '*.*';
+
         return new self(
             sourcePaths: $sourcePaths,
             description: $data['description'] ?? '',
-            filePattern: $data['filePattern'] ?? '*.*',
+            filePattern: $filePattern,
             excludePatterns: $data['excludePatterns'] ?? [],
             showTreeView: $data['showTreeView'] ?? true,
             modifiers: $data['modifiers'] ?? [],
@@ -40,14 +59,14 @@ class FileSource extends BaseSource
     /**
      * @param string $description Human-readable description
      * @param string|array<string> $sourcePaths Paths to source files or directories
-     * @param string $filePattern Pattern to match files
+     * @param string|array<string> $filePattern Pattern(s) to match files
      * @param array<string> $excludePatterns Patterns to exclude files
      * @param array<string> $modifiers Identifiers for content modifiers to apply
      */
     public function __construct(
         public readonly string|array $sourcePaths,
         string $description = '',
-        public readonly string $filePattern = '*.*',
+        public readonly string|array $filePattern = '*.*',
         public readonly array $excludePatterns = [],
         public readonly bool $showTreeView = true,
         public readonly array $modifiers = [],

--- a/src/Source/GithubSource.php
+++ b/src/Source/GithubSource.php
@@ -9,6 +9,38 @@ namespace Butschster\ContextGenerator\Source;
  */
 final class GithubSource extends BaseSource
 {
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['repository'])) {
+            throw new \RuntimeException('GitHub source must have a "repository" property');
+        }
+
+        // Determine source paths (required)
+        if (!isset($data['sourcePaths'])) {
+            throw new \RuntimeException('GitHub source must have a "sourcePaths" property');
+        }
+
+        $sourcePaths = $data['sourcePaths'];
+        if (!\is_string($sourcePaths) && !\is_array($sourcePaths)) {
+            throw new \RuntimeException('"sourcePaths" must be a string or array in source');
+        }
+
+        // Convert to array if single string
+        $sourcePaths = \is_string($sourcePaths) ? [$sourcePaths] : $sourcePaths;
+
+        return new self(
+            repository: $data['repository'],
+            sourcePaths: $sourcePaths,
+            branch: $data['branch'] ?? 'main',
+            description: $data['description'] ?? '',
+            filePattern: $data['filePattern'] ?? '*.php',
+            excludePatterns: $data['excludePatterns'] ?? [],
+            showTreeView: $data['showTreeView'] ?? true,
+            githubToken: $data['githubToken'] ?? null,
+            modifiers: $data['modifiers'] ?? [],
+        );
+    }
+
     /**
      * @param string $repository GitHub repository in format "owner/repo"
      * @param string $branch Branch or tag to fetch from (default: main)
@@ -90,5 +122,20 @@ final class GithubSource extends BaseSource
         }
 
         return $headers;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'type' => 'github',
+            'repository' => $this->repository,
+            'branch' => $this->branch,
+            'description' => $this->description,
+            'filePattern' => $this->filePattern,
+            'excludePatterns' => $this->excludePatterns,
+            'showTreeView' => $this->showTreeView,
+            'githubToken' => $this->githubToken,
+            'modifiers' => $this->modifiers,
+        ]);
     }
 }

--- a/src/Source/TextSource.php
+++ b/src/Source/TextSource.php
@@ -9,6 +9,18 @@ namespace Butschster\ContextGenerator\Source;
  */
 final class TextSource extends BaseSource
 {
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['content']) || !\is_string($data['content'])) {
+            throw new \RuntimeException('Text source must have a "content" string property');
+        }
+
+        return new self(
+            content: $data['content'],
+            description: $data['description'] ?? '',
+        );
+    }
+
     /**
      * @param string $description Human-readable description
      * @param string $content Text content
@@ -18,5 +30,14 @@ final class TextSource extends BaseSource
         string $description = '',
     ) {
         parent::__construct($description);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'type' => 'text',
+            'description' => $this->description,
+            'content' => $this->content,
+        ]);
     }
 }

--- a/src/Source/UrlSource.php
+++ b/src/Source/UrlSource.php
@@ -9,6 +9,19 @@ namespace Butschster\ContextGenerator\Source;
  */
 final class UrlSource extends BaseSource
 {
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['urls']) || !\is_array($data['urls'])) {
+            throw new \RuntimeException('URL source must have a "urls" array property');
+        }
+
+        return new self(
+            urls: $data['urls'],
+            description: $data['description'] ?? '',
+            selector: $data['selector'] ?? null,
+        );
+    }
+
     /**
      * @param array<string> $urls URLs to fetch content from
      * @param string $description Human-readable description
@@ -48,5 +61,15 @@ final class UrlSource extends BaseSource
             description: $this->getDescription(),
             selector: $selector,
         );
+    }
+
+    public function jsonSerialize(): array
+    {
+        return \array_filter([
+            'type' => 'url',
+            'urls' => $this->urls,
+            'description' => $this->getDescription(),
+            'selector' => $this->getSelector(),
+        ]);
     }
 }

--- a/src/SourceInterface.php
+++ b/src/SourceInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator;
 
-interface SourceInterface
+interface SourceInterface extends \JsonSerializable
 {
     /**
      * Get source description


### PR DESCRIPTION
This PR adds support for specifying multiple file patterns in both FileSource and GithubSource configurations. Previously, users could only specify a single file pattern like `*.php`. Now, users can specify an array of patterns to match multiple file types in a single source definition.

## Example Usage

```php
new FileSource(
    sourcePaths: __DIR__ . '/src',
    description: 'Source Code',
    filePattern: ['*.php', '*.md', '*.json'], // Multiple file patterns
    excludePatterns: ['tests', 'vendor'],
)
```

Or in JSON configuration:

```json
{
  "type": "file",
  "description": "Source Code",
  "sourcePaths": ["src"],
  "filePattern": ["*.php", "*.md", "*.json"],
  "excludePatterns": ["tests", "vendor"]
}
```