### PR TITLE
feat: Add InitCommand for CLI configuration setup

### DIFF
--- a/context-generator
+++ b/context-generator
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+declare(strict_types=1);
+
 namespace Butschster\ContextGenerator;
 
 $insidePhar = \str_starts_with(__FILE__, 'phar://');
@@ -22,7 +24,7 @@ $vendorPath = (static function (): string {
         }
     }
 
-    if (null === $file) {
+    if ($file === null) {
         throw new \RuntimeException('Unable to locate autoload.php file.');
     }
 
@@ -31,8 +33,9 @@ $vendorPath = (static function (): string {
     return $file;
 })();
 
-use Butschster\ContextGenerator\Cli\ContextGenerator;
-use Butschster\ContextGenerator\Cli\GetVersion;
+use Butschster\ContextGenerator\Console\GenerateCommand;
+use Butschster\ContextGenerator\Console\InitCommand;
+use Butschster\ContextGenerator\Console\VersionCommand;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use Symfony\Component\Console\Application;
@@ -47,20 +50,27 @@ $appPath = \realpath($vendorPath);
 $version = \file_exists($versionFile) ? \json_decode(\file_get_contents($versionFile), true) : ['version' => 'dev'];
 
 if ($insidePhar) {
-    $appPath = getcwd();
+    $appPath = \getcwd();
 }
 
 $httpClient = new Client();
 $httpMessageFactory = new HttpFactory();
 
 $application->add(
-    new GetVersion(
+    new VersionCommand(
         version: $version['version'] ?? 'dev',
     ),
 );
 
 $application->add(
-    new ContextGenerator(
+    new InitCommand(
+        baseDir: $appPath,
+    ),
+);
+
+
+$application->add(
+    new GenerateCommand(
         rootPath: $appPath,
         outputPath: $appPath . '/.context',
         httpClient: $httpClient,

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Butschster\ContextGenerator\Cli;
+namespace Butschster\ContextGenerator\Console;
 
 use Butschster\ContextGenerator\DocumentCompiler;
 use Butschster\ContextGenerator\Fetcher\SourceFetcherRegistry;
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'generate')]
-final class ContextGenerator extends Command
+final class GenerateCommand extends Command
 {
     public function __construct(
         private readonly string $rootPath,

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Console;
+
+use Butschster\ContextGenerator\Document;
+use Butschster\ContextGenerator\DocumentRegistry;
+use Butschster\ContextGenerator\Source\Text\TextSource;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'init')]
+final class InitCommand extends Command
+{
+    public function __construct(public string $baseDir)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument(
+                name: 'filename',
+                mode: InputArgument::OPTIONAL,
+                description: 'The name of the file to create',
+                default: 'context.json',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filename = $input->getArgument('filename');
+
+        $filePath = \sprintf('%s/%s', $this->baseDir, $filename);
+
+        if (\file_exists($filePath)) {
+            $output->writeln(\sprintf('<error>Config %s already exists</error>', $filePath));
+
+            return Command::FAILURE;
+        }
+
+        $content = \json_encode(new DocumentRegistry([
+            new Document(
+                description: 'Your description here',
+                outputPath: 'context.md',
+                firstSource: new TextSource(
+                    content: 'My first context',
+                    description: 'First context',
+                ),
+            ),
+        ]), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        \file_put_contents($filePath, $content);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Console/VersionCommand.php
+++ b/src/Console/VersionCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Butschster\ContextGenerator\Cli;
+namespace Butschster\ContextGenerator\Console;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'version')]
-final class GetVersion extends Command
+final class VersionCommand extends Command
 {
     public function __construct(private readonly string $version)
     {

--- a/src/Document.php
+++ b/src/Document.php
@@ -68,7 +68,7 @@ final class Document implements \JsonSerializable
             'description' => $this->description,
             'outputPath' => $this->outputPath,
             'overwrite' => $this->overwrite,
-            'sources' => $this->sources,
+            'sources' => \array_values($this->sources),
         ]);
     }
 }

--- a/src/DocumentRegistry.php
+++ b/src/DocumentRegistry.php
@@ -6,10 +6,12 @@ namespace Butschster\ContextGenerator;
 
 final class DocumentRegistry implements \JsonSerializable
 {
-    /**
-     * @var array<Document>
-     */
-    private array $documents = [];
+    public function __construct(
+        /**
+         * @var array<Document>
+         */
+        private array $documents = [],
+    ) {}
 
     /**
      * Register a document in the registry


### PR DESCRIPTION
This PR adds the `InitCommand` to simplify getting started with the Context Generator tool.

## Changes
- Implement `InitCommand` that creates a basic configuration file (context.json)
- Command accepts a filename argument with `context.json` as the default
- Generates a minimal working configuration with a text source example
- Prevents overwriting existing configuration files


```bash
context-generator init
```

This creates a default `context.json` file in your current directory with a basic configuration.

## Custom Filename

You can specify a custom filename for your configuration:

```bash
context-generator init my-context.json
```

This will create a file named `my-context.json` instead of the default `context.json`.

## What It Creates

The command generates a JSON configuration file that looks like this:

```json
{
    "documents": [
        {
            "description": "Your description here",
            "outputPath": "context.md",
            "sources": [
                {
                    "type": "text",
                    "description": "First context",
                    "content": "My first context"
                }
            ]
        }
    ]
}
```