### PR TITLE
Add Variable System for sources data

### DIFF
--- a/src/Document/DocumentsParserPlugin.php
+++ b/src/Document/DocumentsParserPlugin.php
@@ -136,10 +136,6 @@ final readonly class DocumentsParserPlugin implements ConfigParserPluginInterfac
      */
     private function createGithubSource(array $data): GithubSource
     {
-        if (isset($data['githubToken'])) {
-            $data['githubToken'] = ConfigParser::parseConfigValue($data['githubToken']);
-        }
-
         return GithubSource::fromArray($data);
     }
 

--- a/src/Document/DocumentsParserPlugin.php
+++ b/src/Document/DocumentsParserPlugin.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Butschster\ContextGenerator\Document;
 
-use Butschster\ContextGenerator\Loader\ConfigRegistry\ConfigParser;
 use Butschster\ContextGenerator\Loader\ConfigRegistry\DocumentRegistry;
 use Butschster\ContextGenerator\Loader\ConfigRegistry\Parser\ConfigParserPluginInterface;
 use Butschster\ContextGenerator\Loader\ConfigRegistry\RegistryInterface;

--- a/src/Lib/Variable/Provider/CompositeVariableProvider.php
+++ b/src/Lib/Variable/Provider/CompositeVariableProvider.php
@@ -18,7 +18,7 @@ final class CompositeVariableProvider implements VariableProviderInterface
      * @param array<VariableProviderInterface> $providers
      */
     public function __construct(
-        VariableProviderInterface ...$providers
+        VariableProviderInterface ...$providers,
     ) {
         foreach ($providers as $provider) {
             $this->addProvider($provider);
@@ -39,7 +39,7 @@ final class CompositeVariableProvider implements VariableProviderInterface
      */
     public function addProviderWithHighPriority(VariableProviderInterface $provider): self
     {
-        array_unshift($this->providers, $provider);
+        \array_unshift($this->providers, $provider);
         return $this;
     }
 

--- a/src/Lib/Variable/Provider/CompositeVariableProvider.php
+++ b/src/Lib/Variable/Provider/CompositeVariableProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+/**
+ * Provider that aggregates multiple providers with prioritization
+ */
+final class CompositeVariableProvider implements VariableProviderInterface
+{
+    /**
+     * @var array<VariableProviderInterface> List of providers in priority order
+     */
+    private array $providers = [];
+
+    /**
+     * @param array<VariableProviderInterface> $providers
+     */
+    public function __construct(
+        VariableProviderInterface ...$providers
+    ) {
+        foreach ($providers as $provider) {
+            $this->addProvider($provider);
+        }
+    }
+
+    /**
+     * Add a provider with the lowest priority
+     */
+    public function addProvider(VariableProviderInterface $provider): self
+    {
+        $this->providers[] = $provider;
+        return $this;
+    }
+
+    /**
+     * Add a provider with the highest priority
+     */
+    public function addProviderWithHighPriority(VariableProviderInterface $provider): self
+    {
+        array_unshift($this->providers, $provider);
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->has($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function get(string $name): ?string
+    {
+        foreach ($this->providers as $provider) {
+            if ($provider->has($name)) {
+                return $provider->get($name);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<VariableProviderInterface>
+     */
+    public function getProviders(): array
+    {
+        return $this->providers;
+    }
+}

--- a/src/Lib/Variable/Provider/CustomVariableProvider.php
+++ b/src/Lib/Variable/Provider/CustomVariableProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+/**
+ * Provider for custom user-defined variables
+ * todo: add into a settings section
+ */
+final class CustomVariableProvider implements VariableProviderInterface
+{
+    /**
+     * @var array<string, string> Map of variable names to values
+     */
+    private array $variables = [];
+
+    /**
+     * Set a variable value
+     *
+     * @param string $name Variable name
+     * @param string $value Variable value
+     * @return self
+     */
+    public function set(string $name, string $value): self
+    {
+        $this->variables[$name] = $value;
+        return $this;
+    }
+
+    /**
+     * Set multiple variables at once
+     *
+     * @param array<string, string> $variables Map of variable names to values
+     * @return self
+     */
+    public function setMany(array $variables): self
+    {
+        foreach ($variables as $name => $value) {
+            $this->set($name, $value);
+        }
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->variables);
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->variables[$name] ?? null;
+    }
+
+    /**
+     * Get all variables
+     *
+     * @return array<string, string>
+     */
+    public function all(): array
+    {
+        return $this->variables;
+    }
+
+    /**
+     * Remove a variable
+     *
+     * @param string $name Variable name
+     * @return self
+     */
+    public function remove(string $name): self
+    {
+        unset($this->variables[$name]);
+        return $this;
+    }
+
+    /**
+     * Clear all variables
+     *
+     * @return self
+     */
+    public function clear(): self
+    {
+        $this->variables = [];
+        return $this;
+    }
+}

--- a/src/Lib/Variable/Provider/CustomVariableProvider.php
+++ b/src/Lib/Variable/Provider/CustomVariableProvider.php
@@ -20,7 +20,6 @@ final class CustomVariableProvider implements VariableProviderInterface
      *
      * @param string $name Variable name
      * @param string $value Variable value
-     * @return self
      */
     public function set(string $name, string $value): self
     {
@@ -32,7 +31,6 @@ final class CustomVariableProvider implements VariableProviderInterface
      * Set multiple variables at once
      *
      * @param array<string, string> $variables Map of variable names to values
-     * @return self
      */
     public function setMany(array $variables): self
     {
@@ -44,7 +42,7 @@ final class CustomVariableProvider implements VariableProviderInterface
 
     public function has(string $name): bool
     {
-        return array_key_exists($name, $this->variables);
+        return \array_key_exists($name, $this->variables);
     }
 
     public function get(string $name): ?string
@@ -66,7 +64,6 @@ final class CustomVariableProvider implements VariableProviderInterface
      * Remove a variable
      *
      * @param string $name Variable name
-     * @return self
      */
     public function remove(string $name): self
     {
@@ -77,7 +74,6 @@ final class CustomVariableProvider implements VariableProviderInterface
     /**
      * Clear all variables
      *
-     * @return self
      */
     public function clear(): self
     {

--- a/src/Lib/Variable/Provider/EnvironmentVariableProvider.php
+++ b/src/Lib/Variable/Provider/EnvironmentVariableProvider.php
@@ -19,7 +19,7 @@ final readonly class EnvironmentVariableProvider implements VariableProviderInte
     public function has(string $name): bool
     {
         $envName = $this->prefix . $name;
-        return isset($_ENV[$envName]) || isset($_SERVER[$envName]) || getenv($envName) !== false;
+        return isset($_ENV[$envName]) || isset($_SERVER[$envName]) || \getenv($envName) !== false;
     }
 
     public function get(string $name): ?string
@@ -31,7 +31,7 @@ final readonly class EnvironmentVariableProvider implements VariableProviderInte
         }
 
         if (isset($_SERVER[$envName])) {
-            return $_SERVER[$envName];
+            return (string) $_SERVER[$envName];
         }
 
         $value = \getenv($envName);

--- a/src/Lib/Variable/Provider/EnvironmentVariableProvider.php
+++ b/src/Lib/Variable/Provider/EnvironmentVariableProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+/**
+ * Provider that reads variables from environment variables
+ */
+final readonly class EnvironmentVariableProvider implements VariableProviderInterface
+{
+    /**
+     * @param string $prefix Prefix for environment variables (optional)
+     */
+    public function __construct(
+        private string $prefix = '',
+    ) {}
+
+    public function has(string $name): bool
+    {
+        $envName = $this->prefix . $name;
+        return isset($_ENV[$envName]) || isset($_SERVER[$envName]) || getenv($envName) !== false;
+    }
+
+    public function get(string $name): ?string
+    {
+        $envName = $this->prefix . $name;
+
+        if (isset($_ENV[$envName])) {
+            return $_ENV[$envName];
+        }
+
+        if (isset($_SERVER[$envName])) {
+            return $_SERVER[$envName];
+        }
+
+        $value = \getenv($envName);
+        return $value !== false ? $value : null;
+    }
+}

--- a/src/Lib/Variable/Provider/PredefinedVariableProvider.php
+++ b/src/Lib/Variable/Provider/PredefinedVariableProvider.php
@@ -9,6 +9,16 @@ namespace Butschster\ContextGenerator\Lib\Variable\Provider;
  */
 final readonly class PredefinedVariableProvider implements VariableProviderInterface
 {
+    public function has(string $name): bool
+    {
+        return \array_key_exists($name, $this->getPredefinedVariables());
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->getPredefinedVariables()[$name] ?? null;
+    }
+
     /**
      * Get all predefined variables
      *
@@ -17,26 +27,16 @@ final readonly class PredefinedVariableProvider implements VariableProviderInter
     private function getPredefinedVariables(): array
     {
         return [
-            'DATETIME' => date('Y-m-d H:i:s'),
-            'DATE' => date('Y-m-d'),
-            'TIME' => date('H:i:s'),
-            'TIMESTAMP' => (string) time(),
-            'USER' => get_current_user(),
-            'HOME_DIR' => getenv('HOME') ?: (getenv('USERPROFILE') ?: '/'),
-            'TEMP_DIR' => sys_get_temp_dir(),
+            'DATETIME' => \date('Y-m-d H:i:s'),
+            'DATE' => \date('Y-m-d'),
+            'TIME' => \date('H:i:s'),
+            'TIMESTAMP' => (string) \time(),
+            'USER' => \get_current_user(),
+            'HOME_DIR' => \getenv('HOME') ?: (\getenv('USERPROFILE') ?: '/'),
+            'TEMP_DIR' => \sys_get_temp_dir(),
             'OS' => PHP_OS,
-            'HOSTNAME' => gethostname() ?: 'unknown',
-            'PWD' => getcwd() ?: '.',
+            'HOSTNAME' => \gethostname() ?: 'unknown',
+            'PWD' => \getcwd() ?: '.',
         ];
-    }
-
-    public function has(string $name): bool
-    {
-        return array_key_exists($name, $this->getPredefinedVariables());
-    }
-
-    public function get(string $name): ?string
-    {
-        return $this->getPredefinedVariables()[$name] ?? null;
     }
 }

--- a/src/Lib/Variable/Provider/PredefinedVariableProvider.php
+++ b/src/Lib/Variable/Provider/PredefinedVariableProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+/**
+ * Provider with predefined system variables
+ */
+final readonly class PredefinedVariableProvider implements VariableProviderInterface
+{
+    /**
+     * Get all predefined variables
+     *
+     * @return array<string, string>
+     */
+    private function getPredefinedVariables(): array
+    {
+        return [
+            'DATETIME' => date('Y-m-d H:i:s'),
+            'DATE' => date('Y-m-d'),
+            'TIME' => date('H:i:s'),
+            'TIMESTAMP' => (string) time(),
+            'USER' => get_current_user(),
+            'HOME_DIR' => getenv('HOME') ?: (getenv('USERPROFILE') ?: '/'),
+            'TEMP_DIR' => sys_get_temp_dir(),
+            'OS' => PHP_OS,
+            'HOSTNAME' => gethostname() ?: 'unknown',
+            'PWD' => getcwd() ?: '.',
+        ];
+    }
+
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->getPredefinedVariables());
+    }
+
+    public function get(string $name): ?string
+    {
+        return $this->getPredefinedVariables()[$name] ?? null;
+    }
+}

--- a/src/Lib/Variable/Provider/VariableProviderInterface.php
+++ b/src/Lib/Variable/Provider/VariableProviderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable\Provider;
+
+/**
+ * Interface for all variable providers
+ */
+interface VariableProviderInterface
+{
+    /**
+     * Check if this provider has a variable with the given name
+     */
+    public function has(string $name): bool;
+
+    /**
+     * Get the value of a variable
+     *
+     * @param string $name Variable name
+     * @return string|null Variable value or null if not found
+     */
+    public function get(string $name): ?string;
+}

--- a/src/Lib/Variable/VariableReplacementProcessor.php
+++ b/src/Lib/Variable/VariableReplacementProcessor.php
@@ -27,17 +27,17 @@ final readonly class VariableReplacementProcessor
     public function process(string $text): string
     {
         // Replace ${VAR_NAME} syntax
-        $result = preg_replace_callback(
+        $result = \preg_replace_callback(
             '/\${([a-zA-Z0-9_]+)}/',
             fn(array $matches) => $this->replaceVariable($matches[1]),
             $text,
         );
 
         // Replace {{VAR_NAME}} syntax
-        return preg_replace_callback(
+        return \preg_replace_callback(
             '/{{([a-zA-Z0-9_]+)}}/',
             fn(array $matches) => $this->replaceVariable($matches[1]),
-            $result,
+            (string) $result,
         );
     }
 

--- a/src/Lib/Variable/VariableReplacementProcessor.php
+++ b/src/Lib/Variable/VariableReplacementProcessor.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable;
+
+use Butschster\ContextGenerator\Lib\Variable\Provider\EnvironmentVariableProvider;
+use Butschster\ContextGenerator\Lib\Variable\Provider\VariableProviderInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Processor that replaces variable references in text
+ */
+final readonly class VariableReplacementProcessor
+{
+    public function __construct(
+        private VariableProviderInterface $provider = new EnvironmentVariableProvider(),
+        private ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Process text by replacing variable references
+     *
+     * @param string $text Text containing variable references
+     * @return string Text with variables replaced
+     */
+    public function process(string $text): string
+    {
+        // Replace ${VAR_NAME} syntax
+        $result = preg_replace_callback(
+            '/\${([a-zA-Z0-9_]+)}/',
+            fn(array $matches) => $this->replaceVariable($matches[1]),
+            $text,
+        );
+
+        // Replace {{VAR_NAME}} syntax
+        return preg_replace_callback(
+            '/{{([a-zA-Z0-9_]+)}}/',
+            fn(array $matches) => $this->replaceVariable($matches[1]),
+            $result,
+        );
+    }
+
+    /**
+     * Replace a single variable reference
+     *
+     * @param string $name Variable name
+     * @return string Variable value or original reference if not found
+     */
+    private function replaceVariable(string $name): string
+    {
+        if (!$this->provider->has($name)) {
+            // Keep the original reference if not found and not failing
+            return '${' . $name . '}';
+        }
+
+        // Get the variable value
+        $value = $this->provider->get($name);
+
+        $this->logger?->debug('Replacing variable', [
+            'name' => $name,
+            'value' => $value,
+        ]);
+
+        // If value is null (should not happen due to has() check), return empty string
+        return $value ?? '';
+    }
+}

--- a/src/Lib/Variable/VariableResolver.php
+++ b/src/Lib/Variable/VariableResolver.php
@@ -15,9 +15,6 @@ final readonly class VariableResolver
 
     /**
      * Resolve variables in the given text
-     *
-     * @param string|array<string>|null $strings
-     * @return string|array<string>|null Text with variables replaced
      */
     public function resolve(string|array|null $strings): string|array|null
     {
@@ -26,7 +23,7 @@ final readonly class VariableResolver
         }
 
         if (\is_array($strings)) {
-            return \array_map([$this, 'resolve'], $strings);
+            return \array_map($this->resolve(...), $strings);
         }
 
         return $this->processor->process($strings);

--- a/src/Lib/Variable/VariableResolver.php
+++ b/src/Lib/Variable/VariableResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Butschster\ContextGenerator\Lib\Variable;
+
+/**
+ * Main service for resolving variables in strings
+ */
+final readonly class VariableResolver
+{
+    public function __construct(
+        private VariableReplacementProcessor $processor = new VariableReplacementProcessor(),
+    ) {}
+
+    /**
+     * Resolve variables in the given text
+     *
+     * @param string|array<string>|null $strings
+     * @return string|array<string>|null Text with variables replaced
+     */
+    public function resolve(string|array|null $strings): string|array|null
+    {
+        if ($strings === null) {
+            return null;
+        }
+
+        if (\is_array($strings)) {
+            return \array_map([$this, 'resolve'], $strings);
+        }
+
+        return $this->processor->process($strings);
+    }
+}

--- a/src/Loader/ConfigRegistry/ConfigParser.php
+++ b/src/Loader/ConfigRegistry/ConfigParser.php
@@ -26,46 +26,6 @@ final readonly class ConfigParser implements ConfigParserInterface
     }
 
     /**
-     * Parse environment variables in configuration values
-     *
-     * @param string|null $value The configuration value to parse
-     * @return string|null The parsed value
-     */
-    public static function parseConfigValue(?string $value): ?string
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        // Check if the value is an environment variable reference
-        if (\preg_match('/^\${([A-Za-z0-9_]+)}$/', $value, $matches)) {
-            // Get the environment variable name
-            $envName = $matches[1];
-
-            // Get the value from environment
-            $envValue = \getenv($envName);
-
-            // Return the environment variable value or null if not set
-            return $envValue !== false ? $envValue : null;
-        }
-
-        // Check if the value has embedded environment variables
-        if (\preg_match_all('/\${([A-Za-z0-9_]+)}/', $value, $matches)) {
-            // Replace all environment variables in the string
-            foreach ($matches[0] as $index => $placeholder) {
-                $envName = $matches[1][$index];
-                $envValue = \getenv($envName);
-
-                if ($envValue !== false) {
-                    $value = \str_replace($placeholder, $envValue, $value);
-                }
-            }
-        }
-
-        return $value;
-    }
-
-    /**
      * Parse a JSON configuration array
      *
      * @param array<mixed> $config The configuration array

--- a/src/Source/Composer/ComposerSourceFetcher.php
+++ b/src/Source/Composer/ComposerSourceFetcher.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Source\Composer;
 use Butschster\ContextGenerator\Fetcher\SourceFetcherInterface;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\Source\Composer\Provider\ComposerProviderInterface;
 use Butschster\ContextGenerator\Source\File\FileSource;
@@ -29,6 +30,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
         private string $basePath = '.',
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         private FileTreeBuilder $treeBuilder = new FileTreeBuilder(),
+        private VariableResolver $variableResolver = new VariableResolver(),
         private ?LoggerInterface $logger = null,
     ) {
         // Create a FileSourceFetcher to handle the actual file fetching
@@ -60,8 +62,10 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
             throw new \InvalidArgumentException($errorMessage);
         }
 
+        $description = $this->variableResolver->resolve($source->getDescription());
+
         $this->logInfo('Fetching Composer source content', [
-            'description' => $source->getDescription(),
+            'description' => $description,
             'composerPath' => $source->composerPath,
             'includeDevDependencies' => $source->includeDevDependencies,
         ]);
@@ -69,7 +73,7 @@ final readonly class ComposerSourceFetcher implements SourceFetcherInterface
         // Create a content builder
         $builder = $this->builderFactory
             ->create()
-            ->addTitle($source->getDescription());
+            ->addTitle($description);
 
         // Get packages from the provider
         $packages = $this->provider->getPackages(

--- a/src/Source/Github/GithubFinder.php
+++ b/src/Source/Github/GithubFinder.php
@@ -15,6 +15,7 @@ use Butschster\ContextGenerator\Lib\PathFilter\FilePatternFilter;
 use Butschster\ContextGenerator\Lib\PathFilter\FilterInterface;
 use Butschster\ContextGenerator\Lib\PathFilter\PathFilter;
 use Butschster\ContextGenerator\Lib\TreeBuilder\FileTreeBuilder;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 
 /**
  * GitHub content finder implementation
@@ -35,6 +36,7 @@ final class GithubFinder implements FinderInterface
      */
     public function __construct(
         private readonly GithubClientInterface $githubClient,
+        private readonly VariableResolver $variableResolver = new VariableResolver(),
         private readonly FileTreeBuilder $fileTreeBuilder = new FileTreeBuilder(),
     ) {}
 
@@ -48,7 +50,7 @@ final class GithubFinder implements FinderInterface
         }
 
         if ($source->githubToken) {
-            $this->githubClient->setToken($source->githubToken);
+            $this->githubClient->setToken($this->variableResolver->resolve($source->githubToken));
         }
 
         // Parse repository from string

--- a/src/Source/Text/TextSourceFetcher.php
+++ b/src/Source/Text/TextSourceFetcher.php
@@ -7,6 +7,7 @@ namespace Butschster\ContextGenerator\Source\Text;
 use Butschster\ContextGenerator\Fetcher\SourceFetcherInterface;
 use Butschster\ContextGenerator\Lib\Content\Block\TextBlock;
 use Butschster\ContextGenerator\Lib\Content\ContentBuilderFactory;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\SourceInterface;
 use Psr\Log\LoggerInterface;
@@ -19,6 +20,7 @@ final readonly class TextSourceFetcher implements SourceFetcherInterface
 {
     public function __construct(
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
+        private VariableResolver $variableResolver = new VariableResolver(),
         private ?LoggerInterface $logger = null,
     ) {}
 
@@ -42,8 +44,10 @@ final readonly class TextSourceFetcher implements SourceFetcherInterface
             throw new \InvalidArgumentException($errorMessage);
         }
 
+        $description = $this->variableResolver->resolve($source->getDescription());
+
         $this->logger?->info('Fetching text source content', [
-            'description' => $source->getDescription(),
+            'description' => $description,
             'tag' => $source->tag,
             'contentLength' => \strlen($source->content),
         ]);
@@ -52,14 +56,17 @@ final readonly class TextSourceFetcher implements SourceFetcherInterface
         $this->logger?->debug('Creating content builder');
         $builder = $this->builderFactory
             ->create()
-            ->addDescription($source->getDescription());
+            ->addDescription($description);
 
         $this->logger?->debug('Adding text content with tags', [
             'tag' => $source->tag,
         ]);
 
+        $content = $this->variableResolver->resolve($source->content);
+        $tag = $this->variableResolver->resolve($source->tag);
+
         $builder
-            ->addBlock(new TextBlock($modifiersApplier->apply($source->content, 'file.txt'), $source->tag))
+            ->addBlock(new TextBlock($modifiersApplier->apply($content, 'file.txt'), $tag))
             ->addSeparator();
 
         $content = $builder->build();

--- a/src/Source/Url/UrlSourceFetcher.php
+++ b/src/Source/Url/UrlSourceFetcher.php
@@ -11,10 +11,10 @@ use Butschster\ContextGenerator\Lib\Html\HtmlCleanerInterface;
 use Butschster\ContextGenerator\Lib\Html\SelectorContentExtractor;
 use Butschster\ContextGenerator\Lib\Html\SelectorContentExtractorInterface;
 use Butschster\ContextGenerator\Lib\HttpClient\HttpClientInterface;
+use Butschster\ContextGenerator\Lib\Variable\VariableResolver;
 use Butschster\ContextGenerator\Modifier\ModifiersApplierInterface;
 use Butschster\ContextGenerator\SourceInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * Fetcher for URL sources using Butschster HTTP client
@@ -33,13 +33,12 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
             'Accept' => 'text/html,application/xhtml+xml',
             'Accept-Language' => 'en-US,en;q=0.9',
         ],
+        private VariableResolver $variableResolver = new VariableResolver(),
         private HtmlCleanerInterface $cleaner = new HtmlCleaner(),
         private ?SelectorContentExtractorInterface $selectorExtractor = new SelectorContentExtractor(),
         private ContentBuilderFactory $builderFactory = new ContentBuilderFactory(),
         private ?LoggerInterface $logger = null,
-    ) {
-        $this->logger ??= new NullLogger();
-    }
+    ) {}
 
     public function supports(SourceInterface $source): bool
     {
@@ -67,7 +66,9 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
         ]);
 
         // Create builder
-        $builder = $this->builderFactory->create();
+        $builder = $this->builderFactory
+            ->create()
+            ->addDescription($this->variableResolver->resolve($source->getDescription()));
 
         foreach ($source->urls as $index => $url) {
             $this->logger?->debug('Processing URL', [
@@ -77,7 +78,9 @@ final readonly class UrlSourceFetcher implements SourceFetcherInterface
             ]);
 
             try {
-                $requestHeaders = \array_merge($this->defaultHeaders, $source->headers);
+                $requestHeaders = $this->variableResolver->resolve(
+                    \array_merge($this->defaultHeaders, $source->headers),
+                );
 
                 // Send the request
                 $this->logger?->debug('Sending HTTP request', [


### PR DESCRIPTION
This PR adds a robust variable system for the Context Generator, allowing the use of environment variables, predefined system values, and custom variables in source configurations. Variables can be used with `${VAR_NAME}` or `{{VAR_NAME}}` syntax in various source fields.

## Features Added

- Variable system with multiple providers (Environment, Predefined, Custom)
- Support for built-in variables like `${DATETIME}`, `${USER}`, `${HOSTNAME}`
- Composite provider mechanism for prioritized variable resolution
- Integrated with `TextSource`, `UrlSource`, `GithubSource`, `ComposerSource` as a proof of concept

## Example Usage

Variables can be used in source configurations:

```php
[
    'type' => 'text',
    'description' => 'System info as of ${DATETIME}',
    'content' => 'Generated by ${USER} on ${HOSTNAME}',
    'tag' => '${TAG}',
]
```

# Predefined Variables List

## Date and Time
- `${DATETIME}` - Current date and time (format: YYYY-MM-DD HH:MM:SS)
- `${DATE}` - Current date (format: YYYY-MM-DD)
- `${TIME}` - Current time (format: HH:MM:SS)
- `${TIMESTAMP}` - Current Unix timestamp

## System Information
- `${USER}` - Current system user
- `${HOME_DIR}` - User's home directory
- `${TEMP_DIR}` - System temporary directory
- `${OS}` - Operating system name
- `${HOSTNAME}` - Computer hostname
- `${PWD}` - Current working directory

## Environment Variables
All environment variables are also available using the same syntax:
- `${PATH}` - System PATH
- `${LANG}` - System language setting
- And any other environment variables defined in your system

Users can now load variables from specific environment files:

Examples of using the `--env` option:

```bash
# Load variables from default .env file
ctx --env

# Load variables from a specific file
ctx --env=.env.local

# Do not load any environment variables (default behavior)
ctx
```
php bin/console ctx generate --env=.env.local