### PR TITLE
Add Support for Self-Executable Binary Installation

### DIFF
--- a/.github/workflows/build-phar-release.yml
+++ b/.github/workflows/build-phar-release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set current version from ${{ github.ref_name }}
         run: |
-          echo "{\"version\": \"${{ github.ref_name }}\"}" > version.json
+          echo "{\"version\": \"${{ github.ref_name }}\", \"type\":\"phar\"}" > version.json
 
       - uses: ramsey/composer-install@v3
       - name: Build PHAR

--- a/.github/workflows/buld-bin-release.yml
+++ b/.github/workflows/buld-bin-release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Set current version from ${{ github.ref_name }}
         run: |
-          echo "{\"version\": \"${{ github.ref_name }}\"}" > version.json
+          echo "{\"version\": \"${{ github.ref_name }}\", \"type\":\"bin\"}" > version.json
 
       - name: Build Docker image
         uses: docker/build-push-action@v4

--- a/README.md
+++ b/README.md
@@ -119,23 +119,6 @@ If you installed the PHAR in a custom location, specify the path:
 ctx self-update --phar-path=/usr/local/bin/ctx
 ```
 
-### Using PHAR file
-
-Alternatively, you can download the ready-to-use PHAR file directly:
-
-Download and make executable:
-
-```bash
-wget https://github.com/butschster/context-generator/releases/download/1.6.1/context-generator.phar
-chmod +x context-generator.phar
-```
-
-Move it to a convenient location for easy access:
-
-```bash
-mv context-generator.phar /usr/local/bin/ctx
-```
-
 ## Command Reference
 
 Here's the text for the README section about the Generate Context Files command, including the new environment variable

--- a/context-generator
+++ b/context-generator
@@ -78,7 +78,14 @@ $vendorPath = \dirname($vendorPath) . '/../';
 $versionFile = $vendorPath . '/version.json';
 $appPath = \realpath($vendorPath);
 
-$version = \file_exists($versionFile) ? \json_decode(\file_get_contents($versionFile), true) : ['version' => 'dev'];
+$version = \file_exists($versionFile)
+    ? \json_decode(\file_get_contents($versionFile), true)
+    : [
+        'version' => 'dev',
+        'type' => 'phar',
+    ];
+
+$type = $version['type'] ?? 'phar';
 
 if ($insidePhar) {
     $appPath = \getcwd();
@@ -116,6 +123,7 @@ $application->add(
         version: $version['version'] ?? 'dev',
         httpClient: $httpClientAdapter,
         files: new Files(),
+        binaryType: $type,
     ),
 );
 

--- a/download-latest.sh
+++ b/download-latest.sh
@@ -93,7 +93,7 @@ download_and_install() {
 
   # Download the phar file
   printf "Downloading $PNAME $latestV...\n"
-  phar_url="$GITHUB_REL/$latestV/$PNAME.phar"
+  phar_url="$GITHUB_REL/$latestV/$PNAME"
 
   if ! curl --fail -L "$phar_url" -o "$bin_dir/$PNAME"; then
     printf "${RED}ERROR: Failed to download $phar_url${DEFAULT}\n"


### PR DESCRIPTION
This PR enhances the installation options by allowing users to choose between the standard PHP Archive (PHAR) file and a self-executable binary that doesn't require PHP extension.

This change makes the tool more accessible to users who may not have PHP installed on their system or prefer a standalone executable.

```bash
# Update to latest self-executable binary
ctx self-update --type=bin

# Update to latest PHAR version
ctx self-update --type=phar
```

Starting from version `1.14`, the system will automatically detect the currently installed binary type during updates, ensuring users receive the correct format without manual specification.